### PR TITLE
Fix Notify by Playtime

### DIFF
--- a/DrinkWater/DrinkWater.csproj
+++ b/DrinkWater/DrinkWater.csproj
@@ -1,5 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-
 	<PropertyGroup>
 		<TargetFramework>net48</TargetFramework>
 		<OutputType>Library</OutputType>
@@ -32,16 +32,16 @@
 		  <Private>False</Private>
 		</Reference>
 		<Reference Include="Colors, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-		  <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\Colors.dll</HintPath>
+		  <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Colors.dll</HintPath>
 		</Reference>
 		<Reference Include="GameplayCore, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-		  <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\GameplayCore.dll</HintPath>
+		  <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\GameplayCore.dll</HintPath>
 		</Reference>
 		<Reference Include="Hive.Versioning, Version=0.1.0.0, Culture=neutral, PublicKeyToken=null">
-		  <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Libs\Hive.Versioning.dll</HintPath>
+		  <HintPath>$(BeatSaberDir)\Libs\Hive.Versioning.dll</HintPath>
 		</Reference>
 		<Reference Include="Unity.TextMeshPro, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-		  <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\Unity.TextMeshPro.dll</HintPath>
+		  <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Unity.TextMeshPro.dll</HintPath>
 		</Reference>
 		<Reference Include="UnityEngine.CoreModule">
 			<HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.CoreModule.dll</HintPath>

--- a/DrinkWater/Managers/DrinkWaterManager.cs
+++ b/DrinkWater/Managers/DrinkWaterManager.cs
@@ -32,20 +32,30 @@ namespace DrinkWater.Managers
 			if (!_pluginConfig.EnablePlugin) return;
 
 			var practiceSettings = _standardLevelScenesTransitionSetupData.practiceSettings;
-			if (practiceSettings != null)
-				_playTime += (obj.endSongTime - practiceSettings.startSongTime) / practiceSettings.songSpeedMul;
-			else
-				_playTime += obj.endSongTime / obj.gameplayModifiers.songSpeedMul;
-			_playCount += 1;
+
+			var songPlayDuration = practiceSettings == null
+				? obj.endSongTime
+				: obj.endSongTime - practiceSettings.startSongTime;
+
+			var songSpeedMul = practiceSettings?.songSpeedMul ?? obj.gameplayModifiers.songSpeedMul;
 			
-			if (_pluginConfig.EnableByPlaytime && _playTime >= _pluginConfig.PlaytimeBeforeWarning)
+			_siraLog.Info($"Song duration {songPlayDuration}, " +
+			              $"Speed Multiplier {songSpeedMul}, " +
+			              $"Actual playtime {songPlayDuration / songSpeedMul}");
+			
+			_playTime += songPlayDuration / songSpeedMul;
+			_playCount += 1;
+			// playtime we get from the game is in second, config playtime setting is in minute
+			if (_pluginConfig.EnableByPlaytime && _playTime >= _pluginConfig.PlaytimeBeforeWarning * 60)
 			{
+				_siraLog.Debug($"Playtime: {_playTime}, Setting: {_pluginConfig.PlaytimeBeforeWarning * 60}");
 				_siraLog.Info("Required play time met");
 				_drinkWaterPanelController.displayPanelNeeded = true;
 				_playTime = 0f;
 			}
 			else if (_pluginConfig.EnableByPlaycount && _playCount >= _pluginConfig.PlaycountBeforeWarning)
 			{
+				_siraLog.Debug($"PlayCount: {_playCount}, Setting: {_pluginConfig.PlaycountBeforeWarning}");
 				_siraLog.Info("Required play count met");
 				_drinkWaterPanelController.displayPanelNeeded = true;
 				_playCount = 0;

--- a/DrinkWater/Managers/DrinkWaterManager.cs
+++ b/DrinkWater/Managers/DrinkWaterManager.cs
@@ -51,14 +51,20 @@ namespace DrinkWater.Managers
 				_siraLog.Debug($"Playtime: {_playTime}, Setting: {_pluginConfig.PlaytimeBeforeWarning * 60}");
 				_siraLog.Info("Required play time met");
 				_drinkWaterPanelController.displayPanelNeeded = true;
+				// reset both playtime and playCount
+				// otherwise we may get notification by play count right after a playtime notification
+				// or vise-versa
 				_playTime = 0f;
+				_playCount = 0;
 			}
 			else if (_pluginConfig.EnableByPlaycount && _playCount >= _pluginConfig.PlaycountBeforeWarning)
 			{
 				_siraLog.Debug($"PlayCount: {_playCount}, Setting: {_pluginConfig.PlaycountBeforeWarning}");
 				_siraLog.Info("Required play count met");
 				_drinkWaterPanelController.displayPanelNeeded = true;
+				// same here
 				_playCount = 0;
+				_playTime = 0f;
 			}
 		}
 

--- a/DrinkWater/manifest.json
+++ b/DrinkWater/manifest.json
@@ -3,9 +3,9 @@
   "id": "DrinkWater",
   "name": "DrinkWater",
   "author": "Sirspam",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Beat Saber mod to remind you of the importance of hydration",
-  "gameVersion": "1.20.0",
+  "gameVersion": "1.21.0",
   "icon": "DrinkWater.Resources.AquaDrink.png",
     "dependsOn": {
       "BSIPA": "^4.2.2",


### PR DESCRIPTION
Accumulated playtime (in seconds) was compared directly with config playtime (in minutes).

This causes the player to be notified after each single map play.

Added some more log messages.

I also updated the csproj to use BeatSaberDir.